### PR TITLE
account for varying lengths for sparse likelihoods

### DIFF
--- a/megabeast/beast_data.py
+++ b/megabeast/beast_data.py
@@ -40,7 +40,7 @@ def read_lnp_data(filename, nstars):
         # - find the length of the sparse likelihoods
         lnp_sizes = [lnp_hdf[sname]['lnp'].value.shape[0] for sname in lnp_hdf.keys()]
         # - set arrays to the maximum size
-        lnp_vals = np.zeros((np.max(lnp_sizes), nstars), dtype=float)
+        lnp_vals = np.zeros((np.max(lnp_sizes), nstars), dtype=float) - np.inf
         lnp_indxs = np.zeros((np.max(lnp_sizes), nstars), dtype=int)
         
         # loop over all the stars (groups)

--- a/megabeast/beast_data.py
+++ b/megabeast/beast_data.py
@@ -36,16 +36,15 @@ def read_lnp_data(filename, nstars):
         lnp_hdf.close()
         exit()
     else:
+        # initialize arrays
+        # - find the length of the sparse likelihoods
+        lnp_sizes = [lnp_hdf[sname]['lnp'].value.shape[0] for sname in lnp_hdf.keys()]
+        # - set arrays to the maximum size
+        lnp_vals = np.zeros((np.max(lnp_sizes), nstars), dtype=float)
+        lnp_indxs = np.zeros((np.max(lnp_sizes), nstars), dtype=int)
+        
         # loop over all the stars (groups)
-        lnp_init = False
         for k, sname in enumerate(lnp_hdf.keys()):
-            if not lnp_init:
-                istar_lnp = lnp_hdf[sname]['lnp'].value
-                n_ivals, = istar_lnp.shape
-                lnp_vals = np.zeros((n_ivals, nstars), dtype=float)
-                lnp_indxs = np.zeros((n_ivals, nstars), dtype=int)
-                lnp_init = True
-
             lnp_vals[:, k] = lnp_hdf[sname]['lnp'].value
             lnp_indxs[:, k] = np.int64(np.array(lnp_hdf[sname]['idx'].value))
         lnp_hdf.close()

--- a/megabeast/beast_data.py
+++ b/megabeast/beast_data.py
@@ -45,8 +45,8 @@ def read_lnp_data(filename, nstars):
         
         # loop over all the stars (groups)
         for k, sname in enumerate(lnp_hdf.keys()):
-            lnp_vals[:, k] = lnp_hdf[sname]['lnp'].value
-            lnp_indxs[:, k] = np.int64(np.array(lnp_hdf[sname]['idx'].value))
+            lnp_vals[:lnp_sizes[k], k] = lnp_hdf[sname]['lnp'].value
+            lnp_indxs[:lnp_sizes[k], k] = np.int64(np.array(lnp_hdf[sname]['idx'].value))
         lnp_hdf.close()
 
         # shift the log(likelihood) values to have a max of 0.0


### PR DESCRIPTION
Addresses #9:
* find maximum size of the `lnp` lists to initialize the arrays, rather than using the size for the first star
* when assigning a star's `lnp` to the array, explicitly reference the size in the indexing
* initialize the `lnp` array to `-np.inf`: for the shorter sparse likelihoods, these will remain `-np.inf` when doing `lnp_vals -= np.max(lnp_vals)`, and when integrating the probability, `np.exp(-np.inf)` is 0, so they won't contribute to the result.