### PR TITLE
small changes for code readability

### DIFF
--- a/megabeast/beast_data.py
+++ b/megabeast/beast_data.py
@@ -60,7 +60,7 @@ def read_lnp_data(filename, nstars):
 def read_beast_data(filename,
                     noise_filename,
                     beast_params=['Av', 'Rv', 'f_A',
-                                  'M_ini', 'logA', 'Z',
+                                  'M_ini', 'logA', 'Z', 'distance',
                                   'completeness'],
                     verbose=True):
     """
@@ -76,7 +76,7 @@ def read_beast_data(filename,
 
     beast_params: strings
        contains the set of BEAST parameters to extract
-       default = [completeness, Av, Rv, f_A, M_ini, logA, Z]
+       default = [completeness, Av, Rv, f_A, M_ini, logA, Z, distance]
 
     Returns
     -------

--- a/megabeast/beast_data.py
+++ b/megabeast/beast_data.py
@@ -119,7 +119,7 @@ def extract_beast_data(beast_data, lnp_data):
 
     Returns
     -------
-    beast_on_lnp: dictonary
+    lnp_grid_vals: dictonary
        contains arrays of the beast parameters and priors for the sparse
        lnp saved model grid points
     """
@@ -127,16 +127,16 @@ def extract_beast_data(beast_data, lnp_data):
     beast_params = beast_data.keys()
 
     # setup the output
-    beast_on_lnp = {}
+    lnp_grid_vals = {}
     n_lnps, n_stars = lnp_data['indxs'].shape
     for cparam in beast_params:
-        beast_on_lnp[cparam] = np.empty((n_lnps, n_stars), dtype=float)
+        lnp_grid_vals[cparam] = np.empty((n_lnps, n_stars), dtype=float)
 
     # loop over the stars and extract the requested BEAST data
     # for k in tqdm(range(n_stars), desc='extracting beast data'):
     for k in range(n_stars):
         for cparam in beast_params:
-            beast_on_lnp[cparam][:, k] = \
+            lnp_grid_vals[cparam][:, k] = \
                             beast_data[cparam][lnp_data['indxs'][:, k]]
 
-    return beast_on_lnp
+    return lnp_grid_vals

--- a/megabeast/ensemble_model.py
+++ b/megabeast/ensemble_model.py
@@ -87,7 +87,7 @@ def _two_lognorm(xs,
     return pointwise
 
 
-def lnlike(phi, model_weights, lnp_data, lnp_grid_vals):
+def lnlike(phi, beast_dust_priors, lnp_data, lnp_grid_vals):
     """
     Compute the log(likelihood) for the ensemble parameters
 
@@ -96,7 +96,7 @@ def lnlike(phi, model_weights, lnp_data, lnp_grid_vals):
     phi: floats
        ensemble parameters
 
-    model_weights: PriorWeightsDust object
+    beast_dust_priors: PriorWeightsDust object
        contains the data and functions for the dust ensemble model
 
     lnp_data: dictonary
@@ -116,10 +116,10 @@ def lnlike(phi, model_weights, lnp_data, lnp_grid_vals):
     # compute the ensemble model for all the model grid points for all stars
     #   temp code for development
     #   will change to using the PriorWeightsDust for production
-    n_lnps, n_stars = model_weights.av_vals.shape
-    new_prior = np.empty(model_weights.av_vals.shape, dtype=float)
+    n_lnps, n_stars = beast_dust_priors.av_vals.shape
+    new_prior = np.empty(beast_dust_priors.av_vals.shape, dtype=float)
     for k in range(n_stars):
-        new_prior[:, k] = _two_lognorm(model_weights.av_vals[:, k],
+        new_prior[:, k] = _two_lognorm(beast_dust_priors.av_vals[:, k],
                                        max_pos1, max_pos2,
                                        sigma1=sigma1, sigma2=sigma2,
                                        N1=N1, N2=N2)
@@ -130,7 +130,7 @@ def lnlike(phi, model_weights, lnp_data, lnp_grid_vals):
     # weights are those that adjust the saved likelihoods for the new
     # ensemble model (ensemble "priors")
     #   save as log to allow easy summing later
-    weight_ratio = new_prior/model_weights.av_priors
+    weight_ratio = new_prior/beast_dust_priors.av_priors
 
     # compute the each star's integrated probability that it fits the new model
     # including the completeness function
@@ -187,7 +187,7 @@ def lnprior(phi):
         return -np.inf
 
 
-def lnprob(phi, model_weights, lnp_data, lnp_grid_vals):
+def lnprob(phi, beast_dust_priors, lnp_data, lnp_grid_vals):
     """
     Compute the log(likelihood) for the ensemble parameters
 
@@ -196,7 +196,7 @@ def lnprob(phi, model_weights, lnp_data, lnp_grid_vals):
     phi: floats
        ensemble parameters
 
-    model_weights: PriorWeightsDust object
+    beast_dust_priors: PriorWeightsDust object
        contains the data and functions for the dust ensemble model
 
     lnp_data: dictonary
@@ -214,4 +214,4 @@ def lnprob(phi, model_weights, lnp_data, lnp_grid_vals):
 
     if not np.isfinite(ln_prior):
         return -np.inf
-    return ln_prior + lnlike(phi, model_weights, lnp_data, lnp_grid_vals)
+    return ln_prior + lnlike(phi, beast_dust_priors, lnp_data, lnp_grid_vals)

--- a/megabeast/ensemble_model.py
+++ b/megabeast/ensemble_model.py
@@ -87,7 +87,7 @@ def _two_lognorm(xs,
     return pointwise
 
 
-def lnlike(phi, model_weights, lnp_data, beast_on_lnp):
+def lnlike(phi, model_weights, lnp_data, lnp_grid_vals):
     """
     Compute the log(likelihood) for the ensemble parameters
 
@@ -102,7 +102,7 @@ def lnlike(phi, model_weights, lnp_data, beast_on_lnp):
     lnp_data: dictonary
        contains arrays of the lnp values and indexs to the BEAST model grid
 
-    beast_on_lnp: dictonary
+    lnp_grid_vals: dictonary
        contains arrays of the beast parameters and priors for the sparse
        lnp saved model grid points
 
@@ -135,7 +135,7 @@ def lnlike(phi, model_weights, lnp_data, beast_on_lnp):
     # compute the each star's integrated probability that it fits the new model
     # including the completeness function
     star_probs = np.sum(weight_ratio
-                        * beast_on_lnp['completeness']
+                        * lnp_grid_vals['completeness']
                         * np.exp(lnp_data['vals']), axis=0)
 
     # remove any results that have zero integrated probabilities
@@ -144,7 +144,7 @@ def lnlike(phi, model_weights, lnp_data, beast_on_lnp):
 
     # print(np.sum(new_prior,axis=0))
     # print(np.sum(np.exp(lnp_data['vals']),axis=0))
-    # print(np.sum(beast_on_lnp['completeness'],axis=0))
+    # print(np.sum(lnp_grid_vals['completeness'],axis=0))
     # print(star_probs)
     # print('---')
     # print(star_probs[indxs])
@@ -187,7 +187,7 @@ def lnprior(phi):
         return -np.inf
 
 
-def lnprob(phi, model_weights, lnp_data, beast_on_lnp):
+def lnprob(phi, model_weights, lnp_data, lnp_grid_vals):
     """
     Compute the log(likelihood) for the ensemble parameters
 
@@ -202,7 +202,7 @@ def lnprob(phi, model_weights, lnp_data, beast_on_lnp):
     lnp_data: dictonary
        contains arrays of the lnp values and indexs to the BEAST model grid
 
-    beast_on_lnp: dictonary
+    lnp_grid_vals: dictonary
        contains arrays of the beast parameters and priors for the sparse
        lnp saved model grid points
 
@@ -214,4 +214,4 @@ def lnprob(phi, model_weights, lnp_data, beast_on_lnp):
 
     if not np.isfinite(ln_prior):
         return -np.inf
-    return ln_prior + lnlike(phi, model_weights, lnp_data, beast_on_lnp)
+    return ln_prior + lnlike(phi, model_weights, lnp_data, lnp_grid_vals)

--- a/megabeast/megabeast.py
+++ b/megabeast/megabeast.py
@@ -76,13 +76,13 @@ def megabeast(megabeast_input_file, verbose=True):
 
                 # get the completeness and BEAST model parameters for the
                 #   same grid points as the sparse likelihoods
-                beast_on_lnp = extract_beast_data(beast_data, lnp_data)
+                lnp_grid_vals = extract_beast_data(beast_data, lnp_data)
 
                 # initialize the ensemble model with the parameters used
                 # for the saved BEAST model run results
                 #   currently only dust parameters allowed
                 #   for testing -> only Av
-                avs = beast_on_lnp['Av']
+                avs = lnp_grid_vals['Av']
                 rvs = [3.1]#beast_data['Rv']
                 fAs = [1.0]#beast_data['f_A']
                 dustpriors = PriorWeightsDust(avs, mb_settings['av_prior_model'],
@@ -94,7 +94,7 @@ def megabeast(megabeast_input_file, verbose=True):
                 N12_init = 0.5*nstars_image[i,j]
                 result = op.minimize(chi2,
                                      [0.1,0.7,0.5,0.5,N12_init,N12_init],
-                                     args=(dustpriors, lnp_data, beast_on_lnp),
+                                     args=(dustpriors, lnp_data, lnp_grid_vals),
                                      method='Nelder-Mead')
                 best_fit_images[i,j,:] = result['x']
                 #print(result)

--- a/megabeast/megabeast.py
+++ b/megabeast/megabeast.py
@@ -85,16 +85,16 @@ def megabeast(megabeast_input_file, verbose=True):
                 avs = lnp_grid_vals['Av']
                 rvs = [3.1]#beast_data['Rv']
                 fAs = [1.0]#beast_data['f_A']
-                dustpriors = PriorWeightsDust(avs, mb_settings['av_prior_model'],
-                                              rvs, mb_settings['rv_prior_model'],
-                                              fAs, mb_settings['fA_prior_model'])
+                beast_dust_priors = PriorWeightsDust(avs, mb_settings['av_prior_model'],
+                                                rvs, mb_settings['rv_prior_model'],
+                                                fAs, mb_settings['fA_prior_model'])
 
                 # standard minimization to find initial values
                 chi2 = lambda * args: -1.0*lnprob(*args)
                 N12_init = 0.5*nstars_image[i,j]
                 result = op.minimize(chi2,
                                      [0.1,0.7,0.5,0.5,N12_init,N12_init],
-                                     args=(dustpriors, lnp_data, lnp_grid_vals),
+                                     args=(beast_dust_priors, lnp_data, lnp_grid_vals),
                                      method='Nelder-Mead')
                 best_fit_images[i,j,:] = result['x']
                 #print(result)

--- a/megabeast/plot_input_data.py
+++ b/megabeast/plot_input_data.py
@@ -89,11 +89,11 @@ def plot_input_data(megabeast_input_file, chi2_plot=[]):
 
                 # get the completeness and BEAST model parameters for the
                 #   same grid points as the sparse likelihoods
-                beast_on_lnp = extract_beast_data(beast_data, lnp_data)
+                lnp_grid_vals = extract_beast_data(beast_data, lnp_data)
                 
                 # grab the things we want to plot
-                plot_av = beast_on_lnp['Av']
-                plot_comp = beast_on_lnp['completeness']
+                plot_av = lnp_grid_vals['Av']
+                plot_comp = lnp_grid_vals['completeness']
  
                 for n in range(nstars_image[i,j]):
 


### PR DESCRIPTION
Changing some variable names to make the code easier to understand (at least for me?):
* `beast_on_lnp` is now `lnp_grid_vals`: this holds the dictionary in which each key is a fitted BEAST parameter, and each value is an array (shape = (n_lnps, n_stars)) that holds the parameter associated with the sparsely-sampled `lnp`s for each star
* `model_weight` (in `ensemble_model.py`) and `dustpriors` (in `megabeast.py`) are now `beast_dust_priors`: this is the `PriorWeightsDust` object

I also added the new `distance` parameter to the default list in `read_beast`.