### PR TITLE
simulations of A_V

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,6 +16,7 @@ User Documentation
 
    Motivation and Goals <megabeast/goals.rst>
    How to run <megabeast/running.rst>
+   Creating simulated data <megabeast/simulate.rst>
 
 Installation
 ============

--- a/docs/megabeast/running.rst
+++ b/docs/megabeast/running.rst
@@ -109,7 +109,18 @@ MegaBEAST outputs
 The results of the MegaBEAST are the best fit values for the ensemble model
 for the A(V) distribution.  Currently, only the A(V) ensemble model is
 implemented.  The output filenames have the format
-projectname_param_bestfit.fits where the allowed values of param are
-N1, N2, AV1, AV2, sigma1, and sigma2.  There are two lognormal components in
-the A(V) ensemble model where the lognormal paramters are N (number of stars),
-AV (peak A(V)), and sigma (width of lognormal).
+`projectname_param_bestfit.fits` where the allowed values of param are
+`AV1`, `AV2`, `sigma1`, `sigma2`, and `N12_ratio`.  There are two lognormal components in
+the A(V) ensemble model where the lognormal parameters are N (number of stars),
+AV (A(V) at the peak of the distribution), and sigma (width of lognormal).
+The MegaBEAST does not fit for the total number of stars, so only the the ratio between
+the normalizations of the two lognormals (`N12_ratio`) is fit.
+
+Maps of the best fit parameters can be created with `parameter_maps.py`.  The optional
+input `n_col` (default is 2) sets the number of columns of plots to put on the page.
+
+.. code-block:: shell
+
+  >>> from parameter_maps import parameter_maps 
+  >>> parameter_maps('megabeast_input.txt', n_col=2)
+ 

--- a/docs/megabeast/simulate.rst
+++ b/docs/megabeast/simulate.rst
@@ -32,27 +32,37 @@ This creates the simulated files, runs the MegaBEAST, and makes plots.
 
 .. code-block:: shell
 
-  >>> from simulate_av import simulate_av
-  >>> from megabeast import megabeast
-  >>> from plot_input_data import plot_input_data
+  >>> from megabeast.simulations.simulate_av import simulate_av
+  >>> from megabeast.simulations.simulate_av_plots import simulate_av_plots
+  >>> from megabeast.megabeast import megabeast
+  >>> from megabeast.plot_input_data import plot_input_data
+  >>> from megabeast.parameter_maps import parameter_maps
+  >>> 
   >>> simulate_av('someproject_beast_seds.grid.hd5',
-                  {'max_pos':1, 'sigma':0.5, 'N':500},
+                  {'max_pos':0.5, 'sigma':0.5, 'N':500},
 		  'mb-simulation',
 		  image_dimen=[8,10],
 		  nstar_per_pix=50)
   >>> megabeast('megabeast_input_mb-simulation.txt')
   >>> plot_input_data('megabeast_input_mb-simulation.txt', log_scale=True)
+  >>> simulate_av_plots('megabeast_input_mb-simulation.txt', log_scale=False,
+                        input_lognormal={'max_pos':0.5, 'sigma':0.5, 'N':500})
+  >>> parameter_maps('megabeast_input_mb-simulation.txt', n_col=2)
 
 This is the same as above, but instead draws A_V from a double lognormal distribution.
 
 .. code-block:: shell
 
   >>> simulate_av('someproject_beast_seds.grid.hd5',
-                  {'max_pos':1, 'sigma':0.5, 'N':500},
+                  {'max_pos':0.5, 'sigma':0.5, 'N':500},
 		  'mb-simulation2',
-		  av_lognorm2={'max_pos':4, 'sigma':0.5, 'N':500}
+		  av_lognorm2={'max_pos':2, 'sigma':0.5, 'N':500}
 		  image_dimen=[8,10],
 		  nstar_per_pix=50)
   >>> megabeast('megabeast_input_mb-simulation2.txt')
   >>> plot_input_data('megabeast_input_mb-simulation2.txt', log_scale=True)
+  >>> simulate_av_plots('megabeast_input_mb-simulation2.txt', log_scale=False,
+                        input_lognormal={'max_pos':0.5, 'sigma':0.5, 'N':500},
+			input_lognormal2={'max_pos':2, 'sigma':0.5, 'N':500})
+  >>> parameter_maps('megabeast_input_mb-simulation2.txt', n_col=2)
 

--- a/docs/megabeast/simulate.rst
+++ b/docs/megabeast/simulate.rst
@@ -1,0 +1,45 @@
+#############################
+Simulations for the MegaBEAST
+#############################
+
+**********
+Background
+**********
+
+To test that the MegaBEAST is behaving as expected, it is important to simulate data and evaluate if the results match the input.  Currently, code is implemented to create a lognormal distribution of A_V values that can be run through the MegaBEAST.  More sophisticated inputs, as well as additional types of simulations, are still necessary.
+
+The code `simulate_av.py` will create all files necessary to run the MegaBEAST.  The inputs are:
+
+  * `beast_seds_filename`: Name of the path+file that contains the BEAST SED grid
+  * `av_lognorm`: parameters for the underlying lognormal A_V distribution
+  * `output_label`: a string used for making output folders and file names
+  * `image_dimen` (optional): dimensions of the fake sky image (default is 10x10)
+  * `nstar_per_pix` (optional): number of stars in each pixel (default is 50)
+
+The code will create an `nstars` image with the specified dimensions.  Each pixel will be populated with a number of stars drawn from a poisson distribution with mean of `nstar_per_pix`.
+In each pixel, each star will be assigned an A_V drawn from the input lognormal distribution. The error on A_V is currently assumed to be 0.2 (that will be made more generalizable in the future).
+The log-likelihoods (`lnp`) are computed at each A_V in the BEAST grid.  Each star is assumed to have a completeness of 1 (which will also be more generalized in the future).
+
+The code creates a folder with the spatially organized log likelihoods, an `nstars` image, and a placeholder noisemodel.  It also writes out a MegaBEAST input file, which can be directly input into the MegaBEAST.
+
+*******
+Example
+*******
+
+This example creates an 8x10 image in which each pixel has 50 stars.  The assumed underlying lognormal distribution of A_V has a peak at A_V=1 and sigma=0.5.  The BEAST grid has A_V spacing of 0.01.
+
+.. code-block:: shell
+
+  >>> from simulate_av import simulate_av
+  >>> from megabeast import megabeast
+  >>> from plot_input_data import plot_input_data
+  >>> simulate_av('someproject_beast_seds.grid.hd5',
+                  {'max_pos':1, 'sigma':0.5, 'N':500},
+		  'mb-simulation',
+		  image_dimen=[8,10],
+		  nstar_per_pix=50)
+  >>> megabeast('megabeast_input_mb-simulation.txt')
+  >>> plot_input_data('megabeast_input_mb-simulation.txt', log_scale=True)
+
+This creates the simulated files, runs the MegaBEAST, and makes plots.
+

--- a/docs/megabeast/simulate.rst
+++ b/docs/megabeast/simulate.rst
@@ -6,18 +6,19 @@ Simulations for the MegaBEAST
 Background
 **********
 
-To test that the MegaBEAST is behaving as expected, it is important to simulate data and evaluate if the results match the input.  Currently, code is implemented to create a lognormal distribution of A_V values that can be run through the MegaBEAST.  More sophisticated inputs, as well as additional types of simulations, are still necessary.
+To test that the MegaBEAST is behaving as expected, it is important to simulate data and evaluate if the results match the input.  Currently, code is implemented to create a lognormal (or double lognormal) distribution of A_V values that can be run through the MegaBEAST.  More sophisticated inputs, as well as additional types of simulations, are still necessary.
 
 The code `simulate_av.py` will create all files necessary to run the MegaBEAST.  The inputs are:
 
   * `beast_seds_filename`: Name of the path+file that contains the BEAST SED grid
   * `av_lognorm`: parameters for the underlying lognormal A_V distribution
   * `output_label`: a string used for making output folders and file names
+  * `av_lognorm2` (optional): if set, makes A_V a double lognormal distribution
   * `image_dimen` (optional): dimensions of the fake sky image (default is 10x10)
   * `nstar_per_pix` (optional): number of stars in each pixel (default is 50)
 
 The code will create an `nstars` image with the specified dimensions.  Each pixel will be populated with a number of stars drawn from a poisson distribution with mean of `nstar_per_pix`.
-In each pixel, each star will be assigned an A_V drawn from the input lognormal distribution. The error on A_V is currently assumed to be 0.2 (that will be made more generalizable in the future).
+In each pixel, each star will be assigned an A_V drawn from the input lognormal (or double lognormal) distribution. The error on A_V is currently assumed to be 0.2 (that will be made more generalizable in the future).
 The log-likelihoods (`lnp`) are computed at each A_V in the BEAST grid.  Each star is assumed to have a completeness of 1 (which will also be more generalized in the future).
 
 The code creates a folder with the spatially organized log likelihoods, an `nstars` image, and a placeholder noisemodel.  It also writes out a MegaBEAST input file, which can be directly input into the MegaBEAST.
@@ -27,6 +28,7 @@ Example
 *******
 
 This example creates an 8x10 image in which each pixel has 50 stars.  The assumed underlying lognormal distribution of A_V has a peak at A_V=1 and sigma=0.5.  The BEAST grid has A_V spacing of 0.01.
+This creates the simulated files, runs the MegaBEAST, and makes plots.
 
 .. code-block:: shell
 
@@ -41,5 +43,16 @@ This example creates an 8x10 image in which each pixel has 50 stars.  The assume
   >>> megabeast('megabeast_input_mb-simulation.txt')
   >>> plot_input_data('megabeast_input_mb-simulation.txt', log_scale=True)
 
-This creates the simulated files, runs the MegaBEAST, and makes plots.
+This is the same as above, but instead draws A_V from a double lognormal distribution.
+
+.. code-block:: shell
+
+  >>> simulate_av('someproject_beast_seds.grid.hd5',
+                  {'max_pos':1, 'sigma':0.5, 'N':500},
+		  'mb-simulation2',
+		  av_lognorm2={'max_pos':4, 'sigma':0.5, 'N':500}
+		  image_dimen=[8,10],
+		  nstar_per_pix=50)
+  >>> megabeast('megabeast_input_mb-simulation2.txt')
+  >>> plot_input_data('megabeast_input_mb-simulation2.txt', log_scale=True)
 

--- a/megabeast/ensemble_model.py
+++ b/megabeast/ensemble_model.py
@@ -122,7 +122,8 @@ def lnlike(phi, beast_dust_priors, lnp_data, lnp_grid_vals):
         new_prior[:, k] = _two_lognorm(beast_dust_priors.av_vals[:, k],
                                        max_pos1, max_pos2,
                                        sigma1=sigma1, sigma2=sigma2,
-                                       N1=N12_ratio, N2=1)
+                                       N1=1 - 1/(N12_ratio+1),
+                                       N2=1/(N12_ratio+1))
         if not np.isfinite(np.sum(new_prior[:, k])):
             print(new_prior[:, k])
             exit()
@@ -180,7 +181,7 @@ def lnprior(phi):
             and 0 <= max_pos1 < 2
             and 0 <= max_pos2 < 3
             and max_pos1 < max_pos2
-            and N12_ratio > 0):
+            and 0.01 < N12_ratio < 100):
         return 0.0
     else:
         return -np.inf

--- a/megabeast/ensemble_model.py
+++ b/megabeast/ensemble_model.py
@@ -111,7 +111,7 @@ def lnlike(phi, beast_dust_priors, lnp_data, lnp_grid_vals):
     log(likelihood): float
     """
     # unpack ensemble parameters (Av only)
-    max_pos1, max_pos2, sigma1, sigma2, N1, N2 = phi
+    max_pos1, max_pos2, sigma1, sigma2, N12_ratio = phi
 
     # compute the ensemble model for all the model grid points for all stars
     #   temp code for development
@@ -122,7 +122,7 @@ def lnlike(phi, beast_dust_priors, lnp_data, lnp_grid_vals):
         new_prior[:, k] = _two_lognorm(beast_dust_priors.av_vals[:, k],
                                        max_pos1, max_pos2,
                                        sigma1=sigma1, sigma2=sigma2,
-                                       N1=N1, N2=N2)
+                                       N1=N12_ratio, N2=1)
         if not np.isfinite(np.sum(new_prior[:, k])):
             print(new_prior[:, k])
             exit()
@@ -173,15 +173,14 @@ def lnprior(phi):
        -infinite if not allowed
     """
     # unpack ensemble parameters (Av only)
-    max_pos1, max_pos2, sigma1, sigma2, N1, N2 = phi
+    max_pos1, max_pos2, sigma1, sigma2, N12_ratio = phi
 
     if (0.05 <= sigma1 < 2
             and 0.05 <= sigma2 < 2
             and 0 <= max_pos1 < 2
             and 0 <= max_pos2 < 3
             and max_pos1 < max_pos2
-            and N1 >= 0
-            and N2 >= 0):
+            and N12_ratio > 0):
         return 0.0
     else:
         return -np.inf

--- a/megabeast/examples/megabeast_input.txt
+++ b/megabeast/examples/megabeast_input.txt
@@ -28,7 +28,7 @@ lnp_file_prefix = ./14675_LMC-5665ne-12232_beast/spatial/14675_LMC-5665ne-12232
 projectname = 14675_LMC-5665ne-12232
 
 # parameters for the megabeast to fit
-fit_param_names = ['Av1', 'Av2', 'sigma1', 'sigma2', 'N1', 'N2']
+fit_param_names = ['Av1', 'Av2', 'sigma1', 'sigma2', 'N12_ratio']
 
 # minimum number of stars need in a pixel for fit
 min_for_fit = 20

--- a/megabeast/examples/megabeast_wrapper.py
+++ b/megabeast/examples/megabeast_wrapper.py
@@ -13,6 +13,7 @@ import numpy as np
 # MegaBEAST imports
 from megabeast import megabeast
 from megabeast import plot_input_data
+from megabeast import parameter_maps
 
 import pdb
 
@@ -45,6 +46,8 @@ def megabeast_wrapper(megabeast_input_file, run_megabeast=False, diagnostic_plot
         print('*********************\n')
         
         megabeast.megabeast(megabeast_input_file, verbose=verbose)
+
+        parameter_maps.parameter_maps(megabeast_input_file)
 
 
     # create diagnostic plots

--- a/megabeast/megabeast.py
+++ b/megabeast/megabeast.py
@@ -91,9 +91,8 @@ def megabeast(megabeast_input_file, verbose=True):
 
                 # standard minimization to find initial values
                 chi2 = lambda * args: -1.0*lnprob(*args)
-                N12_init = 0.5*nstars_image[i,j]
                 result = op.minimize(chi2,
-                                     [0.1,0.7,0.5,0.5,N12_init,N12_init],
+                                     [0.25,2.0, 0.5,0.5, 1],
                                      args=(beast_dust_priors, lnp_data, lnp_grid_vals),
                                      method='Nelder-Mead')
                 best_fit_images[i,j,:] = result['x']

--- a/megabeast/parameter_maps.py
+++ b/megabeast/parameter_maps.py
@@ -1,6 +1,5 @@
 # system
 from __future__ import (absolute_import, division, print_function)
-import argparse
 
 # other packages
 import numpy as np
@@ -11,7 +10,6 @@ from astropy.io import fits
 # megabeast
 from .read_megabeast_input import read_megabeast_input
 
-import pdb
 
 
 def parameter_maps(megabeast_input_file, n_col=2):
@@ -59,11 +57,11 @@ def parameter_maps(megabeast_input_file, n_col=2):
 
         # subplot info
         # - current column and row
-        col_num = p % n_col
-        row_num = p // n_col
+        #col_num = p % n_col
+        #row_num = p // n_col
         # - corresponding dimensions
-        subplot_dimen = [1/n_col * col_num, 1-(1/n_row * (row_num+1)),
-                             1/n_col * (col_num+1), 1-(1/n_row * row_num)]
+        #subplot_dimen = [1/n_col * col_num, 1-(1/n_row * (row_num+1)),
+        #                     1/n_col * (col_num+1), 1-(1/n_row * row_num)]
         #print('p='+str(p)+' col_num='+str(col_num)+' row_num='+str(row_num))
         #print(subplot_dimen)
 

--- a/megabeast/parameter_maps.py
+++ b/megabeast/parameter_maps.py
@@ -1,0 +1,91 @@
+# system
+from __future__ import (absolute_import, division, print_function)
+import argparse
+
+# other packages
+import numpy as np
+import matplotlib.pyplot as plt
+import aplpy
+from astropy.io import fits
+
+# megabeast
+from .read_megabeast_input import read_megabeast_input
+
+import pdb
+
+
+def parameter_maps(megabeast_input_file, n_col=2):
+    """
+    Create maps of the best-fit parameters from the MegaBEAST
+
+    Parameters
+    ----------
+    megabeast_input_file : string
+        Name of the file that contains settings, filenames, etc
+
+    n_col : int (default=2)
+        number of columns of plots in the output file
+
+    """
+
+    # read in the settings from the file
+    mb_settings = read_megabeast_input(megabeast_input_file)
+
+    # get the project name
+    projectname = mb_settings['projectname']
+
+    # list of parameters to plot
+    plot_params = mb_settings['fit_param_names']
+
+    # aspect ratio of the field
+    with fits.open('./'+projectname+'_megabeast/'+projectname+'_'+plot_params[0]+'_bestfit.fits') as hdu:
+        im_size = hdu[0].data.shape
+    
+    
+    # initialize figure
+    size = 4
+    n_row = len(plot_params)//n_col + np.count_nonzero(len(plot_params) % n_col)
+    
+    fig = plt.figure(figsize=(size*n_col, size*im_size[0]/im_size[1]*n_row ))
+
+
+    
+    for p,param in enumerate(plot_params):
+
+        print(param)
+
+        # image file name
+        im_file = './'+projectname+'_megabeast/'+projectname+'_'+param+'_bestfit.fits'
+
+        # subplot info
+        # - current column and row
+        col_num = p % n_col
+        row_num = p // n_col
+        # - corresponding dimensions
+        subplot_dimen = [1/n_col * col_num, 1-(1/n_row * (row_num+1)),
+                             1/n_col * (col_num+1), 1-(1/n_row * row_num)]
+        #print('p='+str(p)+' col_num='+str(col_num)+' row_num='+str(row_num))
+        #print(subplot_dimen)
+
+        #pdb.set_trace()
+
+
+        f1 = aplpy.FITSFigure(im_file, figure=fig, subplot=(n_row, n_col, p+1))
+        #f1 = aplpy.FITSFigure(im_file, figure=fig, subplot=subplot_dimen)
+        f1.show_colorscale(cmap='magma')
+        f1.add_colorbar()
+        #f1.colorbar.set_box([0.12, 0.04, 0.33, 0.02], box_orientation='horizontal') # [xmin, ymin, dx, dy]
+        f1.colorbar.set_font(size=10)
+        f1.axis_labels.set_xtext(param)
+        f1.axis_labels.set_font(size=15)
+        #f1.axis_labels.hide_x()
+        f1.axis_labels.hide_y()
+        f1.tick_labels.hide_x()
+        f1.tick_labels.hide_y()
+        f1.frame.set_linewidth(0)
+        plt.tight_layout()
+
+
+        
+    plt.savefig('./'+projectname+'_megabeast/'+projectname+'_bestfit_maps.pdf')
+    plt.close()

--- a/megabeast/plot_input_data.py
+++ b/megabeast/plot_input_data.py
@@ -91,7 +91,7 @@ def plot_input_data(megabeast_input_file, chi2_plot=[], log_scale=False):
             if nstars_image[i,j] > 20:
 
                 # get info about the fits
-                lnp_filename = "%s_beast/spatial/%s_%i_%i_lnp.hd5"%(projectname,projectname, j, i)
+                lnp_filename = mb_settings['lnp_file_prefix']+"_%i_%i_lnp.hd5"%(j, i)
                 lnp_data = read_lnp_data(lnp_filename, nstars_image[i,j])
 
                 # get the completeness and BEAST model parameters for the

--- a/megabeast/simulations/simulate_av.py
+++ b/megabeast/simulations/simulate_av.py
@@ -1,0 +1,253 @@
+# system
+from __future__ import (absolute_import, division, print_function)
+import argparse
+import os
+import glob
+
+# other packages
+from tqdm import (tqdm, trange)
+import numpy as np
+import scipy.stats
+from astropy.io import fits
+import h5py
+from astropy import wcs
+
+# beast
+from beast.physicsmodel.prior_weights_dust import _lognorm
+from beast.fitting.fit import save_lnp
+
+
+import pdb
+
+
+def simulate_av(beast_seds_filename,
+                    av_lognorm,
+                    output_label,
+                    image_dimen=[10,10],
+                    nstar_per_pix=50):
+    """
+    Create a set of fake data in which A_V follows a log-normal distribution, which can then be run through the megabeast
+
+    Parameters
+    ----------
+    beast_seds_filename : string
+        Name of the file that contains the BEAST SED grid
+
+    av_lognorm : dict
+        Dictionary with parameters for lognormal distribution (keys = 'max_pos', 'sigma', 'N')
+
+    output_label : string
+        label to use for folders and file names
+
+    image_dimen : list of ints (default=[10,10])
+        dimensions (nx by ny) of the fake image
+
+    nstar_per_pix : int (default=50)
+        number of stars per pixel (this will vary between pixels using a Poisson distribution)
+
+    """
+
+    # check that the directory exists
+    if not os.path.exists('./'+output_label+'/'):
+        os.makedirs('./'+output_label+'/')
+
+
+    # read in A_V info from the SED grid data
+    beast_seds_hdf = h5py.File(beast_seds_filename, 'r')
+    beast_av_list = np.unique(beast_seds_hdf['grid']['Av'])
+    # get first index of each A_V
+    sed_grid_length = len(beast_seds_hdf['grid']['Av'])
+    beast_av_ind = [int(sed_grid_length/len(beast_av_list) * i) for i in range(len(beast_av_list))]
+    
+    # create an nstars image
+    nstars_hdu = setup_nstars_image(image_dimen, nstar_per_pix, output_label)
+    
+    # create lnp files for each pixel
+    # - first, delete any existing ones (otherwise new stuff is appended)
+    for f in glob.glob('./'+output_label+'/'+output_label+'_*_*_lnp.hd5'):
+        os.remove(f)
+    # - now make new ones
+    setup_lnp_files(nstars_hdu, av_lognorm, beast_av_list, np.array(beast_av_ind), output_label)
+
+    # create a noise file (currently all stars get completeness=1)
+    setup_noise_file(sed_grid_length, output_label)
+
+    # create a megabeast input file
+    setup_mb_input(beast_seds_filename, output_label)
+    
+
+
+
+def setup_mb_input(beast_seds_filename, output_label):
+    """
+    Write out a megabeast input file
+
+    output_label is enough to construct all the necessary file names
+    """
+
+    file_lines = ['# -----------',
+                      '# BEAST files',
+                      '# -----------',
+                      '',
+                      '# files that contain the SEDs and noise model from the BEAST',
+                      'beast_seds_filename = '+beast_seds_filename,
+                      'beast_noise_filename = ./'+output_label+'/'+output_label+'_noisemodel.hd5',
+                      '',
+                      '# prior models for those',
+                      "av_prior_model = {'name': 'flat'}",
+                      "rv_prior_model = {'name': 'flat'}",
+                      "fA_prior_model = {'name': 'flat'}",
+                      '',
+                      '# fits file that contains the number of stars in each spatially-reordered pixel',
+                      'nstars_filename = ./'+output_label + '/' + output_label+'_nstars.fits',
+                      '',
+                      '# prefix for log likelihoods',
+                      '# file will be constructed as lnp_file_prefix_#_#_lnp.hd5, where #s are the spatially reordered pixel numbers',
+                      'lnp_file_prefix = ./'+output_label + '/' + output_label,
+                      '',
+                      '# ------------------',
+                      '# MegaBEAST settings',
+                      '# ------------------',
+                      '',
+                      '# project name to use for megabeast output files',
+                      '# megabeast outputs will be saved in projectname_megabeast folder',
+                      'projectname = '+output_label,
+                      '',
+                      '# parameters for the megabeast to fit',
+                      "fit_param_names = ['Av1', 'Av2', 'sigma1', 'sigma2', 'N1', 'N2']",
+                      '',
+                      '# minimum number of stars need in a pixel for fit',
+                      'min_for_fit = 20',
+                      '']
+
+    with open('megabeast_input_'+output_label+'.txt','w') as mb_file:
+        for line in file_lines:
+            mb_file.write(line+'\n')
+
+
+def setup_noise_file(sed_grid_length, output_label):
+    """
+    Create a noise file
+
+    Currently, the megabeast only uses the completeness column, but the file
+    also has bias and error columns.  For now, they'll all be set as:
+    bias = 0
+    completeness = 1
+    error = 0
+
+    Each array has shape (n_stars, n_filters) -> use n_filters = 1 for
+    simplicity, since megabeast uses the max completeness
+    """
+
+
+    # create the file
+    with h5py.File('./'+output_label+'/'+output_label+'_noisemodel.hd5','w') as f:
+
+        # create the data sets
+        f.create_dataset('bias', data=np.zeros((sed_grid_length,1)) )
+        f.create_dataset('completeness', data=np.ones((sed_grid_length,1)) )
+        f.create_dataset('error', data=np.zeros((sed_grid_length,1)) )
+
+        
+    
+def setup_lnp_files(nstars_hdu, av_lognorm, av_gridpoints, av_ind, output_label):
+    """
+    Create sparsely sampled lnp files for each pixel
+
+    Parameters
+    ----------
+    nstars_hdu : hdu object
+        hdu with the nstars image
+
+    av_lognorm : dict
+        Dictionary with parameters for lognormal distribution (keys = 'max_pos', 'sigma', 'N')
+
+    av_gridpoints : array
+        array of all the unique A_V values in the BEAST grid
+
+    av_ind : list of ints
+        indices in the BEAST grid for each A_V in av_gridpoints
+
+    output_label : string
+        label to use for folders and file names
+    
+    """
+
+    # dimensions of image
+    nx, ny = nstars_hdu.data.shape
+
+    # create a lognormal distribution
+    av_dist = np.linspace(av_gridpoints[0], av_gridpoints[-1], 500)
+    temp = _lognorm(av_dist, av_lognorm['max_pos'], sigma=av_lognorm['sigma'], N=av_lognorm['N'])
+    lognorm_dist = temp / np.sum(temp)
+    lognorm_cdf = np.cumsum(lognorm_dist)
+
+    # iterate through pixels
+    for i in range(nx):
+        for j in range(ny):
+
+            # number of stars in this pixel
+            nstar = nstars_hdu.data[i,j]
+
+            # initialize a list to save info for lnp file
+            lnp_save_list = []
+
+            # iterate through the stars in this pixel
+            for n in range(nstar):
+                
+                # get an A_V from the lognormal distribution
+                av = np.interp(np.random.random(1), lognorm_cdf, av_dist)
+
+                # calculate probabilities
+                # include errors -> sample from gaussian at each BEAST A_V grid point
+                prob_list = scipy.stats.norm(av, 0.2).pdf(av_gridpoints)
+                prob_list = prob_list / np.sum(prob_list)
+
+                # make a list of the required quantities in the lnp file
+                star_num = n
+                idx = av_ind
+                lnp = np.log(prob_list)
+                chi2 = lnp / (-0.5)
+                sed = [99]
+                lnp_save_list.append([star_num, av_ind, lnp, chi2, sed])
+
+            # save the lnp data
+            #print('i='+str(i)+' j='+str(j)+' nstar='+str(nstar)+' len(lnp_list)='+str(len(lnp_save_list)))
+            save_lnp(output_label+'/'+output_label+'_%i_%i_lnp.hd5'%(j, i), lnp_save_list, False)
+                
+                
+
+    
+def setup_nstars_image(image_dimen, nstar_per_pix, output_label):
+    """
+    Create nstars image
+
+    Returns an HDU with the image
+    """
+
+    # create WCS (exact values don't matter, but the megabeast code requires WCS)
+    # - arbitrary settings
+    dec_delt = 10./3600. # (10 arcsec)
+    ra_delt = dec_delt
+    min_ra, max_ra = 0, image_dimen[0]*ra_delt
+    min_dec, max_dec = 0, image_dimen[1]*dec_delt
+    # - WCS thingy
+    w = wcs.WCS(naxis=2)
+    w.wcs.crpix = np.asarray(image_dimen, dtype=float) / 2.
+    w.wcs.cdelt = [ra_delt, dec_delt]
+    w.wcs.crval = np.asarray([(min_ra+max_ra), (min_dec+max_dec)]) / 2.
+    w.wcs.ctype = ["RA---TAN", "DEC--TAN"]
+    # - turn it into a fits header
+    master_header = w.to_header()
+
+    # create image
+    nstar_array = np.random.poisson(nstar_per_pix, tuple(image_dimen))
+
+    # create HDU
+    hdu = fits.PrimaryHDU(data=nstar_array, header=master_header)
+    
+    hdu.writeto(output_label + '/' + output_label+'_nstars.fits',
+                    overwrite=True)
+
+
+    return hdu

--- a/megabeast/simulations/simulate_av.py
+++ b/megabeast/simulations/simulate_av.py
@@ -119,7 +119,7 @@ def setup_mb_input(beast_seds_filename, output_label):
                       'projectname = '+output_label,
                       '',
                       '# parameters for the megabeast to fit',
-                      "fit_param_names = ['Av1', 'Av2', 'sigma1', 'sigma2', 'N1', 'N2']",
+                      "fit_param_names = ['Av1', 'Av2', 'sigma1', 'sigma2', 'N12_ratio']",
                       '',
                       '# minimum number of stars need in a pixel for fit',
                       'min_for_fit = 20',

--- a/megabeast/simulations/simulate_av.py
+++ b/megabeast/simulations/simulate_av.py
@@ -1,11 +1,9 @@
 # system
 from __future__ import (absolute_import, division, print_function)
-import argparse
 import os
 import glob
 
 # other packages
-from tqdm import (tqdm, trange)
 import numpy as np
 import scipy.stats
 from astropy.io import fits
@@ -16,8 +14,6 @@ from astropy import wcs
 from beast.physicsmodel.prior_weights_dust import _lognorm
 from beast.fitting.fit import save_lnp
 
-
-import pdb
 
 
 def simulate_av(beast_seds_filename,
@@ -220,7 +216,7 @@ def setup_lnp_files(nstars_hdu, av_lognorm, av_gridpoints, av_ind, output_label,
                 lnp = np.log(prob_list)
                 chi2 = lnp / (-0.5)
                 sed = [99]
-                lnp_save_list.append([star_num, av_ind, lnp, chi2, sed])
+                lnp_save_list.append([star_num, idx, lnp, chi2, sed])
 
             # save the lnp data
             #print('i='+str(i)+' j='+str(j)+' nstar='+str(nstar)+' len(lnp_list)='+str(len(lnp_save_list)))

--- a/megabeast/simulations/simulate_av.py
+++ b/megabeast/simulations/simulate_av.py
@@ -23,6 +23,7 @@ import pdb
 def simulate_av(beast_seds_filename,
                     av_lognorm,
                     output_label,
+                    av_lognorm2=None,
                     image_dimen=[10,10],
                     nstar_per_pix=50):
     """
@@ -38,6 +39,9 @@ def simulate_av(beast_seds_filename,
 
     output_label : string
         label to use for folders and file names
+
+    av_lognorm2 : dict (default=None)
+        if set (identical formatting to av_lognorm), makes A_V a double lognormal distribution
 
     image_dimen : list of ints (default=[10,10])
         dimensions (nx by ny) of the fake image
@@ -67,7 +71,8 @@ def simulate_av(beast_seds_filename,
     for f in glob.glob('./'+output_label+'/'+output_label+'_*_*_lnp.hd5'):
         os.remove(f)
     # - now make new ones
-    setup_lnp_files(nstars_hdu, av_lognorm, beast_av_list, np.array(beast_av_ind), output_label)
+    setup_lnp_files(nstars_hdu, av_lognorm, beast_av_list, np.array(beast_av_ind),
+                        output_label, av_lognorm2=av_lognorm2)
 
     # create a noise file (currently all stars get completeness=1)
     setup_noise_file(sed_grid_length, output_label)
@@ -150,7 +155,7 @@ def setup_noise_file(sed_grid_length, output_label):
 
         
     
-def setup_lnp_files(nstars_hdu, av_lognorm, av_gridpoints, av_ind, output_label):
+def setup_lnp_files(nstars_hdu, av_lognorm, av_gridpoints, av_ind, output_label, av_lognorm2=None):
     """
     Create sparsely sampled lnp files for each pixel
 
@@ -171,6 +176,9 @@ def setup_lnp_files(nstars_hdu, av_lognorm, av_gridpoints, av_ind, output_label)
     output_label : string
         label to use for folders and file names
     
+    av_lognorm2 : dict (default=None)
+        if set (identical formatting to av_lognorm), makes A_V a double lognormal distribution
+
     """
 
     # dimensions of image
@@ -179,6 +187,9 @@ def setup_lnp_files(nstars_hdu, av_lognorm, av_gridpoints, av_ind, output_label)
     # create a lognormal distribution
     av_dist = np.linspace(av_gridpoints[0], av_gridpoints[-1], 500)
     temp = _lognorm(av_dist, av_lognorm['max_pos'], sigma=av_lognorm['sigma'], N=av_lognorm['N'])
+    if av_lognorm2 is not None:
+        temp2 = _lognorm(av_dist, av_lognorm2['max_pos'], sigma=av_lognorm2['sigma'], N=av_lognorm2['N'])
+        temp += temp2
     lognorm_dist = temp / np.sum(temp)
     lognorm_cdf = np.cumsum(lognorm_dist)
 

--- a/megabeast/simulations/simulate_av_plots.py
+++ b/megabeast/simulations/simulate_av_plots.py
@@ -1,25 +1,19 @@
 # system
 from __future__ import (absolute_import, division, print_function)
-import argparse
 
 # other packages
 from tqdm import (tqdm, trange)
 import numpy as np
 import matplotlib
 import matplotlib.pyplot as plt
-from matplotlib.backends.backend_pdf import PdfPages
 from astropy.io import fits
 
 # beast
-from beast.physicsmodel.prior_weights_dust import PriorWeightsDust
+from beast.physicsmodel.prior_weights_dust import _lognorm, _two_lognorm
 
 # megabeast
 from ..read_megabeast_input import read_megabeast_input
-from ..beast_data import (read_beast_data, extract_beast_data,
-                        read_lnp_data)
-from ..ensemble_model import lnprob, _lognorm, _two_lognorm
-
-import pdb
+from ..beast_data import (read_beast_data, read_lnp_data)
 
 
 
@@ -120,20 +114,17 @@ def simulate_av_plots(megabeast_input_file, log_scale=False,
                     best_val_ind = np.where(vals == np.max(vals))[0][0]
                     best_av.append(beast_data['Av'][inds[best_val_ind]])
                 best_av = np.array(best_av)
-                #pdb.set_trace()
                 
 
                 # stack up some representation of what's being maximized in ensemble_model.py
                 prob_stack = np.sum(lnp_comp * np.exp(lnp_vals), axis=1)
 
                 # normalize it (since it's not clear what the numbers mean anyway)
-                #pdb.set_trace()
                 #prob_stack = prob_stack / np.sum(prob_stack)
                 prob_stack = prob_stack / np.trapz(prob_stack, av_grid)
 
                 ## stack up the probabilities at each A_V
                 #prob_stack = np.sum(np.exp(lnp_vals), axis=1)
-                #pdb.set_trace()
 
                 # set up the subplot
                 plt.subplot(y_dimen, x_dimen, (y_dimen-i-1)*(x_dimen) + j + 1)

--- a/megabeast/simulations/simulate_av_plots.py
+++ b/megabeast/simulations/simulate_av_plots.py
@@ -1,0 +1,223 @@
+# system
+from __future__ import (absolute_import, division, print_function)
+import argparse
+
+# other packages
+from tqdm import (tqdm, trange)
+import numpy as np
+import matplotlib
+import matplotlib.pyplot as plt
+from matplotlib.backends.backend_pdf import PdfPages
+from astropy.io import fits
+
+# beast
+from beast.physicsmodel.prior_weights_dust import PriorWeightsDust
+
+# megabeast
+from ..read_megabeast_input import read_megabeast_input
+from ..beast_data import (read_beast_data, extract_beast_data,
+                        read_lnp_data)
+from ..ensemble_model import lnprob, _lognorm, _two_lognorm
+
+import pdb
+
+
+
+def simulate_av_plots(megabeast_input_file, log_scale=False,
+                          input_lognormal=None, input_lognormal2=None):
+    """
+    Plot distributions of simulated AVs, and overplot the best fit lognormals
+
+    Parameters
+    ----------
+    megabeast_input_file : string
+        Name of the file that contains settings, filenames, etc
+
+    log_scale : boolean (default=False)
+        If True, make the histogram x-axis a log scale (to visualize log-normal
+        A_V distribution)
+
+    input_lognormal, input_lognormal2 : dict (default=None)
+        Set these to the original values used to create the fake data, and they
+        will also be plotted
+
+    """
+
+    # read in the settings from the file
+    mb_settings = read_megabeast_input(megabeast_input_file)
+
+    # get the project name
+    projectname = mb_settings['projectname']
+
+    # read in the beast data that is needed by all the pixels
+    beast_data = read_beast_data(mb_settings['beast_seds_filename'],
+                                 mb_settings['beast_noise_filename'],
+                                 beast_params=['completeness',
+                                               'Av'])#,'Rv','f_A'])
+    av_grid = np.unique(beast_data['Av'])
+
+    # also make a more finely sampled A_V grid
+    if not log_scale:
+        av_grid_big = np.linspace(np.min(av_grid), np.max(av_grid), 500)
+    else:
+        av_grid_big = np.geomspace(np.min(av_grid), np.max(av_grid), 500)
+
+    # read in the nstars image
+    nstars_image, nstars_header = fits.getdata(mb_settings['nstars_filename'], header=True)    
+    # dimensions of images/plotting
+    y_dimen = nstars_image.shape[0]
+    x_dimen = nstars_image.shape[1]
+
+    # read in the best fits
+    label_list = mb_settings['fit_param_names']
+    best_fits = {}
+    for label in label_list:
+        with fits.open('./'+projectname+'_megabeast/'+projectname+'_'+label+'_bestfit.fits') as hdu:
+            best_fits[label] = hdu[0].data
+
+
+    # set colors for plots
+    cmap = matplotlib.cm.get_cmap('inferno')
+    color_data = cmap(0.0)
+    color_fit = cmap(0.5)
+    if input_lognormal is not None:
+        color_input = cmap(0.85)
+    
+    # -----------------
+    # plotting
+    # -----------------
+
+
+    # set up figure
+    fig = plt.figure(figsize=(x_dimen*2,y_dimen*2))
+
+
+    
+    for i in tqdm(range(y_dimen), desc='y pixels'):
+        for j in tqdm(range(x_dimen), desc='x pixels'):
+    #for i in [0]:
+    #    for j in [12]:
+
+            if nstars_image[i,j] > 20:
+
+
+                # -------- data
+
+                # read in the original lnp data
+                lnp_filename = mb_settings['lnp_file_prefix']+"_%i_%i_lnp.hd5"%(j, i)
+                lnp_data = read_lnp_data(lnp_filename, nstars_image[i,j])
+                lnp_vals = np.array(lnp_data['vals'])
+
+                # completeness for each of the values
+                lnp_comp = beast_data['completeness'][lnp_data['indxs']]
+
+                # best A_V for each star
+                best_av = []
+                for k in range(lnp_vals.shape[1]):
+                    vals = lnp_vals[:,k]
+                    lnp_vals[:,k] = np.log(np.exp(vals) / np.sum(np.exp(vals)))
+                    inds = lnp_data['indxs'][:,k]
+                    best_val_ind = np.where(vals == np.max(vals))[0][0]
+                    best_av.append(beast_data['Av'][inds[best_val_ind]])
+                best_av = np.array(best_av)
+                #pdb.set_trace()
+                
+
+                # stack up some representation of what's being maximized in ensemble_model.py
+                prob_stack = np.sum(lnp_comp * np.exp(lnp_vals), axis=1)
+
+                # normalize it (since it's not clear what the numbers mean anyway)
+                #pdb.set_trace()
+                #prob_stack = prob_stack / np.sum(prob_stack)
+                prob_stack = prob_stack / np.trapz(prob_stack, av_grid)
+
+                ## stack up the probabilities at each A_V
+                #prob_stack = np.sum(np.exp(lnp_vals), axis=1)
+                #pdb.set_trace()
+
+                # set up the subplot
+                plt.subplot(y_dimen, x_dimen, (y_dimen-i-1)*(x_dimen) + j + 1)
+
+                # make a histogram
+                if not log_scale:
+                    plt.plot(av_grid, prob_stack,
+                                 marker='.', ms=0, mew=0,
+                                 linestyle='-', color=color_data, linewidth=4)                   
+                if log_scale:
+                    plt.plot(np.log10(av_grid), prob_stack,
+                                 marker='.', ms=0, mew=0,
+                                 linestyle='-', color=color_data, linewidth=4)
+                    
+                ax = plt.gca()
+
+
+
+                # -------- input lognormal(s)
+
+                if input_lognormal is not None:
+
+                    # create lognormal
+                    lognorm = _lognorm(av_grid_big, input_lognormal['max_pos'],
+                                           input_lognormal['sigma'], input_lognormal['N'])
+
+                    # if there's a second lognormal
+                    if input_lognormal2 is not None:
+                        lognorm += _lognorm(av_grid_big, input_lognormal2['max_pos'],
+                                           input_lognormal2['sigma'], input_lognormal2['N'])
+
+
+                    # normalize it
+                    #lognorm = lognorm / np.sum(lognorm)
+                    lognorm = lognorm / np.trapz(lognorm, av_grid_big)
+
+                    # plot it
+                    #yrange_before = ax.get_ylim()
+                    if not log_scale:
+                        plt.plot(av_grid_big, lognorm,
+                                    marker='.', ms=0, mew=0, linestyle='-', color=color_input, linewidth=2, alpha=0.85)
+                    if log_scale:
+                        plt.plot(np.log10(av_grid_big), lognorm,
+                                    marker='.', ms=0, mew=0, linestyle='-', color=color_input, linewidth=2, alpha=0.85)
+                    #ax.set_ylim(yrange_before)
+                    
+
+                # -------- best fit
+
+                # generate best fit
+                lognorm = _two_lognorm(av_grid_big,
+                                           best_fits['Av1'][i,j], best_fits['Av2'][i,j],
+                                           sigma1=best_fits['sigma1'][i,j],
+                                           sigma2=best_fits['sigma2'][i,j],
+                                           N1=nstars_image[i,j]*(1 - 1/(best_fits['N12_ratio'][i,j]+1)),
+                                           N2=nstars_image[i,j]/(best_fits['N12_ratio'][i,j]+1) )
+
+                # normalize it
+                #lognorm = lognorm / nstars_image[i,j]
+                #lognorm = lognorm / np.sum(lognorm)
+                lognorm = lognorm / np.trapz(lognorm, av_grid_big)
+                
+                # plot it
+                yrange_before = ax.get_ylim()
+                if not log_scale:
+                    plt.plot(av_grid_big, lognorm,
+                                marker='.', ms=0, mew=0, dashes=[3,1.5], color=color_fit, linewidth=2)
+                if log_scale:
+                    plt.plot(np.log10(av_grid_big), lognorm,
+                                marker='.', ms=0, mew=0, dashes=[3,1.5], color=color_fit, linewidth=2)
+                ax.set_ylim(yrange_before)
+
+
+                
+    fig.add_subplot(111, frameon=False)
+    plt.tick_params(labelcolor='none', top='off', bottom='off', left='off', right='off')
+    plt.grid(False)
+    if not log_scale:
+        plt.xlabel(r'$A_V$', size=15)
+    else:
+        plt.xlabel(r'Log $A_V$', size=15)
+    plt.ylabel('PDF', size=15)
+    plt.tight_layout()
+    
+    # save figure
+    plt.savefig('./'+projectname+'_megabeast/'+projectname+'_bestfit_plot.pdf')
+    plt.close()


### PR DESCRIPTION
This creates a simulated A_V dataset, in which the underlying A_V can be a single or double lognormal.  Currently, the simulated A_V values have an error of 0.2 and a completeness of 1, which will need to be generalized in the future.

The inputs are the SED grid file, the parameters of the lognormal(s), and a label for the created files.  The dimensions of the image and the number of stars per pixel are also optional inputs.  The code creates all necessary data files (`lnp`, `nstars`, `noisemodel`) and an input file for the megabeast.

Documentation is included.

Partially addresses #6.